### PR TITLE
Replace deprecated `set_axis_bgcolor` with `set_facecolor`

### DIFF
--- a/conditional_neural_process.ipynb
+++ b/conditional_neural_process.ipynb
@@ -688,7 +688,7 @@
         "  plt.ylim([-2, 2])\n",
         "  plt.grid('off')\n",
         "  ax = plt.gca()\n",
-        "  ax.set_axis_bgcolor('white')\n",
+        "  ax.set_facecolor('white')\n",
         "  plt.show()"
       ]
     },


### PR DESCRIPTION
- Matplotlib breaking change since version `2.0` ([link](https://github.com/scikit-learn/scikit-learn/issues/10762#issuecomment-370980311)).
 - See official deprecation note [here](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.set_axis_bgcolor.html).
